### PR TITLE
[feat]  메인 카테고리 CRUD 서비스 구현

### DIFF
--- a/.github/coderabbit.yml
+++ b/.github/coderabbit.yml
@@ -26,13 +26,15 @@ pull_request:
       - [ ] 있음
       - [ ] 없음
 
-general:
-  preferred_language: ko
-
+language: 'ko-KR'
 reviews:
-  enabled: true
-  language: ko
-  review_status: true
+  auto_review:
+    enabled: true              # 모든 PR을 자동 리뷰
 
-ui:
-  language: ko
+  behavior:
+    explain_code_complexity: true  # 코드의 복잡도를 같이 설명
+    suggest_improvements: true     # 개선점을 적극적으로 제안
+    ask_clarifying_questions: false
+
+  comments:
+    tone: "friendly"             # 친근하게

--- a/src/main/java/com/life/finmate/category/domain/MainCategory.java
+++ b/src/main/java/com/life/finmate/category/domain/MainCategory.java
@@ -2,12 +2,16 @@ package com.life.finmate.category.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 
 @Builder
 @Getter
 public class MainCategory {
+    @Setter
     private Long id;
     private Long userId;
     private String categoryName;
@@ -16,4 +20,14 @@ public class MainCategory {
     private String color;
     private Boolean isSystem;
     private LocalDateTime createdAt;
+
+    public void update(String categoryName, String categoryType, String icon, String color) {
+        if (this.isSystem) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "변경할 수 없는 카테고리입니다.");
+        }
+        if (categoryName != null) this.categoryName = categoryName;
+        if (categoryType != null) this.categoryType = categoryType;
+        if (icon != null) this.icon = icon;
+        if (color != null) this.color = color;
+    }
 }

--- a/src/main/java/com/life/finmate/category/dto/MainCategoryCreateRequestDto.java
+++ b/src/main/java/com/life/finmate/category/dto/MainCategoryCreateRequestDto.java
@@ -1,0 +1,53 @@
+package com.life.finmate.category.dto;
+
+import com.life.finmate.category.domain.MainCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MainCategoryCreateRequestDto {
+    private final Long userId;
+    private final String categoryName;
+    private final String categoryType; // income, expense
+    private final String icon;
+    private final String color;
+    private final Boolean isSystem;
+    private final LocalDateTime createdAt;
+
+    @Builder
+    public MainCategoryCreateRequestDto(Long userId, String categoryName, String categoryType, String icon, String color, Boolean isSystem, LocalDateTime createdAt) {
+        this.userId = userId;
+        this.categoryName = categoryName;
+        this.categoryType = categoryType;
+        this.icon = icon;
+        this.color = color;
+        this.isSystem = isSystem;
+        this.createdAt = createdAt;
+    }
+
+    public MainCategory toEntity() {
+        return MainCategory.builder()
+                .userId(this.userId)
+                .categoryName(this.categoryName)
+                .categoryType(this.categoryType)
+                .icon(this.icon)
+                .color(this.color)
+                .isSystem(this.isSystem)
+                .createdAt(this.createdAt)
+                .build();
+    }
+
+    public MainCategoryCreateRequestDto from(MainCategory mainCategory) {
+        return MainCategoryCreateRequestDto.builder()
+                .userId(mainCategory.getUserId())
+                .categoryName(mainCategory.getCategoryName())
+                .categoryType(mainCategory.getCategoryType())
+                .icon(mainCategory.getIcon())
+                .color(mainCategory.getColor())
+                .isSystem(mainCategory.getIsSystem())
+                .createdAt(mainCategory.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/life/finmate/category/dto/MainCategoryUpdateRequestDto.java
+++ b/src/main/java/com/life/finmate/category/dto/MainCategoryUpdateRequestDto.java
@@ -1,0 +1,43 @@
+package com.life.finmate.category.dto;
+
+import com.life.finmate.category.domain.MainCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MainCategoryUpdateRequestDto {
+    private final String categoryName;
+    private final String categoryType; // income, expense
+    private final String icon;
+    private final String color;
+    private final Boolean isSystem;
+
+    @Builder
+    public MainCategoryUpdateRequestDto(String categoryName, String categoryType, String icon, String color, Boolean isSystem) {
+        this.categoryName = categoryName;
+        this.categoryType = categoryType;
+        this.icon = icon;
+        this.color = color;
+        this.isSystem = isSystem;
+    }
+
+    public MainCategory toEntity() {
+        return MainCategory.builder()
+                .categoryName(this.categoryName)
+                .categoryType(this.categoryType)
+                .icon(this.icon)
+                .color(this.color)
+                .isSystem(this.isSystem)
+                .build();
+    }
+
+    public MainCategoryUpdateRequestDto from(MainCategory mainCategory) {
+        return MainCategoryUpdateRequestDto.builder()
+                .categoryName(mainCategory.getCategoryName())
+                .categoryType(mainCategory.getCategoryType())
+                .icon(mainCategory.getIcon())
+                .color(mainCategory.getColor())
+                .isSystem(mainCategory.getIsSystem())
+                .build();
+    }
+}

--- a/src/main/java/com/life/finmate/category/mapper/MainCategoryMapper.java
+++ b/src/main/java/com/life/finmate/category/mapper/MainCategoryMapper.java
@@ -1,0 +1,8 @@
+package com.life.finmate.category.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface MainCategoryMapper {
+
+}

--- a/src/main/java/com/life/finmate/category/mapper/MainCategoryMapper.java
+++ b/src/main/java/com/life/finmate/category/mapper/MainCategoryMapper.java
@@ -1,8 +1,24 @@
 package com.life.finmate.category.mapper;
 
+import com.life.finmate.category.domain.MainCategory;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface MainCategoryMapper {
 
+    // Create
+    void insertCategory(MainCategory mainCategory);
+
+    // Read
+    Optional<MainCategory> selectMainCategoryById(Long id);
+    List<MainCategory> selectMainCategoriesByUserId(Long id);
+
+    // Update
+    void updateCategoryById(MainCategory mainCategory);
+
+    // Delete
+    void deleteCategoryById(Long id);
 }

--- a/src/main/java/com/life/finmate/category/service/MainCategoryService.java
+++ b/src/main/java/com/life/finmate/category/service/MainCategoryService.java
@@ -1,0 +1,59 @@
+package com.life.finmate.category.service;
+
+import com.life.finmate.category.domain.MainCategory;
+import com.life.finmate.category.dto.MainCategoryCreateRequestDto;
+import com.life.finmate.category.dto.MainCategoryUpdateRequestDto;
+import com.life.finmate.category.mapper.MainCategoryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MainCategoryService {
+
+    private final MainCategoryMapper mainCategoryMapper;
+
+    // Create
+    public MainCategory createMainCategory(MainCategoryCreateRequestDto mainCategoryCreateRequestDto) {
+        MainCategory mainCategory = mainCategoryCreateRequestDto.toEntity();
+        mainCategoryMapper.insertCategory(mainCategory);
+
+        return mainCategory;
+    }
+
+    // Read-List
+    public List<MainCategory> findAllMainCategoryByUserId(Long userId) {
+        return mainCategoryMapper.selectMainCategoriesByUserId(userId);
+
+    }
+
+    // Read-One
+    public MainCategory findMainCategoryById(Long id) {
+        return mainCategoryMapper.selectMainCategoryById(id).orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "NOT FOUND : " + id)
+        );
+
+    }
+
+    // Update
+    public MainCategory updateMainCategory(Long id, MainCategoryUpdateRequestDto updateRequestDto) {
+        MainCategory categoryEntity = findMainCategoryById(id);
+        categoryEntity.update(
+                updateRequestDto.getCategoryName(),
+                updateRequestDto.getCategoryType(),
+                updateRequestDto.getIcon(),
+                updateRequestDto.getColor()
+        );
+        mainCategoryMapper.updateCategoryById(categoryEntity);
+        return categoryEntity;
+    }
+
+    // Delete
+    public void deleteMainCategoryById(Long id) {
+        mainCategoryMapper.deleteCategoryById(id);
+    }
+}

--- a/src/main/java/com/life/finmate/goal/controller/GoalController.java
+++ b/src/main/java/com/life/finmate/goal/controller/GoalController.java
@@ -37,7 +37,7 @@ public class GoalController {
 
     @PostMapping()
     public ResponseEntity<GoalResponseDto> createGoal(@RequestBody GoalCreateRequestDto goalCreateRequestDto) {
-        Goal save = goalService.save(goalCreateRequestDto);
+        Goal save = goalService.createGoal(goalCreateRequestDto);
         GoalResponseDto responseDto = GoalResponseDto.from(save);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }

--- a/src/main/java/com/life/finmate/goal/service/GoalService.java
+++ b/src/main/java/com/life/finmate/goal/service/GoalService.java
@@ -18,7 +18,7 @@ public class GoalService {
 
     private final GoalMapper goalMapper;
 
-    public Goal save(GoalCreateRequestDto goalCreateRequestDto) {
+    public Goal createGoal(GoalCreateRequestDto goalCreateRequestDto) {
         Goal goal = goalCreateRequestDto.toEntity();
         goalMapper.save(goal);
         return goal;

--- a/src/main/resources/mapper/category/MainCategoryMapper.xml
+++ b/src/main/resources/mapper/category/MainCategoryMapper.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.life.finmate.category.mapper.MainCategoryMapper">
+
+    <resultMap id="MainCategoryResultMap" type="com.life.finmate.category.domain.MainCategory">
+        <id property="id" column="id"/>
+        <result property="userId" column="user_id"/>
+        <result property="categoryName" column="category_name"/>
+        <result property="categoryType" column="category_type"/>
+        <result property="icon" column="icon"/>
+        <result property="color" column="color"/>
+        <result property="isSystem" column="is_system"/>
+        <result property="createdAt" column="created_at"/>
+    </resultMap>
+
+    <!-- Create -->
+    <insert id="insertCategory" parameterType="com.example.domain.Category" useGeneratedKeys="true" keyProperty="id">
+    INSERT INTO main_categories(
+        user_id,
+        category_name,
+        category_type,
+        icon,
+        color,
+        is_system
+    )
+    VALUES (
+        #{userId},
+        #{categoryName},
+        #{categoryType},
+        #{icon},
+        #{color},
+        #{isSystem}
+    )
+    </insert>
+
+    <!-- Read-one -->
+    <select id="selectMainCategoryById" parameterType="java.lang.Long" resultType="com.life.finmate.category.domain.MainCategory">
+       SELECT * FROM main_categories WHERE id = #{id}
+    </select>
+
+    <!-- Read-one -->
+    <select id="selectMainCategoriesByUserId" parameterType="java.lang.Long" resultType="com.life.finmate.category.domain.MainCategory">
+        SELECT * FROM main_categories WHERE user_id= #{userId}
+    </select>
+
+    <!-- Update -->
+    <update id="updateCategoryById" parameterType="com.life.finmate.category.domain.MainCategory">
+        UPDATE main_categories
+        SET
+            user_id = #{userId},
+            category_name = #{categoryName},
+            category_type = #{categoryType},
+            icon = #{icon},
+            color = #{color},
+            is_system = #{isSystem},
+            created_at = #{createdAt}
+        WHERE
+            id = #{id}
+    </update>
+
+    <!-- Delete-->
+    <delete id="deleteCategoryById" parameterType="java.lang.Long">
+        DELETE FROM main_categories
+        WHERE id = #{id}
+    </delete>
+</mapper>

--- a/src/test/java/com/life/finmate/category/service/MainCategoryServiceTest.java
+++ b/src/test/java/com/life/finmate/category/service/MainCategoryServiceTest.java
@@ -1,0 +1,191 @@
+package com.life.finmate.category.service;
+
+import com.life.finmate.category.domain.MainCategory;
+import com.life.finmate.category.dto.MainCategoryCreateRequestDto;
+import com.life.finmate.category.dto.MainCategoryUpdateRequestDto;
+import com.life.finmate.category.mapper.MainCategoryMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MainCategoryServiceTest {
+
+    @Mock
+    private MainCategoryMapper mainCategoryMapper;
+
+    @Spy
+    @InjectMocks
+    private MainCategoryService mainCategoryService;
+
+    @DisplayName("메인 카테고리 생성 성공 테스트")
+    @Test
+    void createMainCategory_success() {
+        // given
+        MainCategoryCreateRequestDto mainCategory = MainCategoryCreateRequestDto.builder()
+                .categoryName("Category Name")
+                .icon("Icon")
+                .color("Color")
+                .categoryType("income")
+                .createdAt(LocalDateTime.now())
+                .userId(1L)
+                .build();
+        doAnswer(invocation -> {
+            MainCategory categoryArgument = invocation.getArgument(0);
+            categoryArgument.setId(1L);
+            return null;
+        })
+                .when(mainCategoryMapper).insertCategory(any(MainCategory.class));
+
+        // when
+        MainCategory foundCategory = mainCategoryService.createMainCategory(mainCategory);
+
+        // then
+        assertThat(foundCategory).isNotNull(); // 반환된 객체가 null이 아닌지 확인
+        assertThat(foundCategory.getCategoryName()).isEqualTo(mainCategory.getCategoryName()); // 요청한 이름과 일치하는지 확인
+        verify(this.mainCategoryMapper, times(1)).insertCategory(any(MainCategory.class));
+    }
+
+    @Test
+    @DisplayName("유저 아이디 별 list를 조회하는 성공 테스트")
+    void findAllMainCategoryByUserId_success() {
+        // given
+        Long userId = 1L;
+        List<MainCategory> expectedCategories = new ArrayList<>();
+        for (int i = 1; i < 6; i++) {
+            expectedCategories.add(MainCategory.builder()
+                    .id((long) i)
+                    .categoryName("Category Name" + i)
+                    .icon("Icon")
+                    .color("Color")
+                    .categoryType("income")
+                    .createdAt(LocalDateTime.now())
+                    .userId(userId)
+                    .build());
+        }
+
+        when(mainCategoryMapper.selectMainCategoriesByUserId(userId)).thenReturn(expectedCategories);
+
+        // when
+        List<MainCategory> actualCategories = mainCategoryService.findAllMainCategoryByUserId(userId);
+
+        //then
+        assertThat(actualCategories).isNotNull();
+        assertThat(actualCategories).hasSize(5);
+        assertThat(actualCategories).isEqualTo(expectedCategories);
+        verify(mainCategoryMapper, times(1)).selectMainCategoriesByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("단일 카테고리를 조회하는 성공 테스트")
+    void findMainCategoryById_success() {
+        // given
+        Long userId = 1L;
+        Long id = 1L;
+        MainCategory expectedCategory = MainCategory.builder()
+                .id(id)
+                .categoryName("Category Name")
+                .icon("Icon")
+                .color("Color")
+                .categoryType("income")
+                .createdAt(LocalDateTime.now())
+                .userId(userId)
+                .build();
+        when(mainCategoryMapper.selectMainCategoryById(id)).thenReturn(Optional.ofNullable(expectedCategory));
+
+        //when
+        MainCategory actualCategory = mainCategoryService.findMainCategoryById(id);
+
+
+        //then
+        assertThat(actualCategory).isNotNull();
+        assertThat(actualCategory.getId()).isEqualTo(id);
+        verify(this.mainCategoryMapper, times(1)).selectMainCategoryById(id);
+
+    }
+
+    @Test
+    @DisplayName("카테고리 업데이트를 성공하는 테스트")
+    void updateMainCategory_success() {
+        // given
+        Long userId = 1L;
+        Long id = 1L;
+        String updatedName = "testName";
+        MainCategory initialCategory = MainCategory.builder()
+                .id(id)
+                .categoryName("Category Name")
+                .icon("Icon")
+                .color("Color")
+                .categoryType("income")
+                .createdAt(LocalDateTime.now())
+                .userId(userId)
+                .build();
+        MainCategoryUpdateRequestDto updateRequestDto = MainCategoryUpdateRequestDto.builder()
+                .categoryName(updatedName)
+                .icon("Icon")
+                .color("Color")
+                .categoryType("income")
+                .build();
+
+        when(mainCategoryMapper.selectMainCategoryById(id)).thenReturn(Optional.of(initialCategory));
+        doAnswer(invocation -> {
+            MainCategory categoryToUpdate = invocation.getArgument(0);
+            categoryToUpdate.update(
+                    updateRequestDto.getCategoryName(),
+                    updateRequestDto.getCategoryType(),
+                    updateRequestDto.getIcon(),
+                    updateRequestDto.getColor()
+            );
+            return null;
+        }).when(mainCategoryMapper).updateCategoryById(any(MainCategory.class));
+
+        //when
+
+        MainCategory actualCategory = mainCategoryService.updateMainCategory(id, updateRequestDto);
+
+        //then
+        assertThat(actualCategory).isNotNull();
+        assertThat(actualCategory.getId()).isEqualTo(id);
+        assertThat(actualCategory.getCategoryName()).isEqualTo(updatedName);
+        verify(this.mainCategoryMapper, times(1)).selectMainCategoryById(id);
+        verify(this.mainCategoryMapper, times(1)).updateCategoryById(any(MainCategory.class));
+    }
+
+    @DisplayName("카테고리를 삭제하는 성공 테스트")
+    @Test
+    void deleteMainCategoryById() {
+        // given
+        Long id = 1L;
+        MainCategory initialCategory = MainCategory.builder()
+                .id(id)
+                .categoryName("Category Name")
+                .icon("Icon")
+                .color("Color")
+                .categoryType("income")
+                .createdAt(LocalDateTime.now())
+                .userId(1L)
+                .build();
+
+        doNothing().when(mainCategoryMapper).deleteCategoryById(id);
+
+        // when
+        mainCategoryService.deleteMainCategoryById(id);
+
+        // then
+        verify(this.mainCategoryMapper, times(1)).deleteCategoryById(id);
+        assertThat(this.mainCategoryMapper.selectMainCategoryById(id)).isEmpty();
+
+    }
+}

--- a/src/test/java/com/life/finmate/goal/service/GoalServiceTest.java
+++ b/src/test/java/com/life/finmate/goal/service/GoalServiceTest.java
@@ -26,7 +26,7 @@ class GoalServiceTest {
 
     @Test
     @DisplayName("목표를 저장하는 테스트")
-    void save() {
+    void createGoal() {
         // given
         GoalCreateRequestDto goalDto = GoalCreateRequestDto.builder()
                 .userId(1L)
@@ -38,7 +38,7 @@ class GoalServiceTest {
                 .build();
 
         // when
-        Goal save = goalService.save(goalDto);
+        Goal save = goalService.createGoal(goalDto);
 
         // then
         assertThat(save).isNotNull();
@@ -58,7 +58,7 @@ class GoalServiceTest {
                     .currentAmount(0L)
                     .targetDate(LocalDate.now())
                     .build();
-            goalService.save(goalDto);
+            goalService.createGoal(goalDto);
         }
 
        //when
@@ -85,7 +85,7 @@ class GoalServiceTest {
                 .currentAmount(0L)
                 .targetDate(LocalDate.now())
                 .build();
-        Goal save = goalService.save(goalDto);
+        Goal save = goalService.createGoal(goalDto);
 
         // when
         System.out.println(save.getId());
@@ -111,7 +111,7 @@ class GoalServiceTest {
                 .currentAmount(0L)
                 .targetDate(LocalDate.now())
                 .build();
-        Goal save = goalService.save(goalDto);
+        Goal save = goalService.createGoal(goalDto);
 
         GoalUpdateRequestDto updateGoalData = GoalUpdateRequestDto.builder()
                 .goalName(newGoalName)
@@ -136,7 +136,7 @@ class GoalServiceTest {
                 .currentAmount(0L)
                 .targetDate(LocalDate.now())
                 .build();
-        Goal save = goalService.save(goalDto);
+        Goal save = goalService.createGoal(goalDto);
 
         //when
         goalService.deleteById(save.getId());


### PR DESCRIPTION
  ## 🚀 작업 내용
   - 메인 카테고리(MainCategory)에 대한 CRUD 기능을 구현했습니다.
   - MainCategoryService를 추가하여 비즈니스 로직을 처리합니다.
   - MainCategoryCreateRequestDto와 MainCategoryUpdateRequestDto를 추가하여 데이터 전송을 관리합니다.
   - MainCategoryServiceTest를 추가하여 서비스의 기본 동작을 검증하는 단위 테스트를 작성했습니다.

  ## 🔗 관련 이슈
   - Close #17 (이슈가 있다면 여기에 번호를 넣어주세요)

  ##  💬 기타 사항
   - 테스트 코드 수정 및 보완이 필요하여 추가 작업을 진행할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category management functionality enabling creation, retrieval, updates, and deletion of categories
  * Implemented system category protection to prevent accidental modifications

* **Chores**
  * Updated code review tool configuration with Korean language support and enhanced review behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->